### PR TITLE
no more sqlstore Collection.remove()

### DIFF
--- a/app/registry.js
+++ b/app/registry.js
@@ -282,7 +282,7 @@ function storeAuthorRelations(pkg, collection, authors, role) {
     }).forEach(function(author) {
         var relation = RelPackageAuthor.get(pkg, author, role);
         relation.remove();
-        collection.remove(author);
+        collection.invalidate();
         log.info("Removed", author.name, "as", role, "from", pkg.name);
     })
     return;


### PR DESCRIPTION
I emptied the "contributors" array and tried to re-upload the package and got an error

```
309278 [qtp1637238525-23] ERROR .home.simon.rpr.app.api.packages  - TypeError: Cannot find 
function remove in object [Collection contributors]. (/home/simon/rpr/app/registry.js#285)
Script stack:
at /home/simon/rpr/app/registry.js:146 (publishPackage)
at /home/simon/rpr/app/api/packages.js:136 (anonymous)
```
